### PR TITLE
allow setting cookie expiration in CookieOptions

### DIFF
--- a/feature/cloudfront/sign/sign_cookie.go
+++ b/feature/cloudfront/sign/sign_cookie.go
@@ -20,9 +20,10 @@ const (
 // A CookieOptions optional additional options that can be applied to the signed
 // cookies.
 type CookieOptions struct {
-	Path   string
-	Domain string
-	Secure bool
+	Path    string
+	Domain  string
+	Secure  bool
+	Expires time.Time
 }
 
 // apply will integration the options provided into the base cookie options
@@ -230,11 +231,12 @@ func createCookies(p *Policy, keyID string, privKey *rsa.PrivateKey, opt CookieO
 
 	cookies := []*http.Cookie{cPolicy, cSignature, cKey}
 
-	// Applie the cookie options
+	// Apply the cookie options
 	for _, c := range cookies {
 		c.Path = opt.Path
 		c.Domain = opt.Domain
 		c.Secure = opt.Secure
+		c.Expires = opt.Expires
 	}
 
 	return cookies, nil

--- a/feature/cloudfront/sign/sign_cookie_test.go
+++ b/feature/cloudfront/sign/sign_cookie_test.go
@@ -91,7 +91,7 @@ func TestSignCookie_WithCookieOptions(t *testing.T) {
 		o.Path = "/"
 		o.Domain = ".example.com"
 		o.Secure = true
-
+		o.Expires = expires
 	})
 
 	if err != nil {
@@ -116,6 +116,9 @@ func TestSignCookie_WithCookieOptions(t *testing.T) {
 		}
 		if !c.Secure {
 			t.Errorf("expect to be true")
+		}
+		if e, a := expires, c.Expires; e != a {
+			t.Errorf("expect %v, got %v", e, a)
 		}
 	}
 }


### PR DESCRIPTION
This PR updates the `feature/cloudfront/sign` module to allow a user to set cookie expiration through CookieOptions.